### PR TITLE
Continue middleware at end of call

### DIFF
--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -5,11 +5,11 @@ export async function middleware(req: NextRequest, event: NextFetchEvent) {
   const { geo } = req
   console.log({geo})
 
-  const res = NextResponse.next()
+  const res = NextResponse;
   const weather = await weatherAPI(geo.city.normalize("NFD").replace(/[\u0300-\u036f]/g, ""), process.env.WEATHER_API_KEY)
 
   // const weather = await weatherAPI(geo.city.normalize('NFD').replace(/[\u0300-\u036f]/g, ""), process.env.WEATHER_API_KEY)
   const visitorsWeather = weather.current.condition.text || 'No weather data'
   res.headers.append('x-visitors-weather',  visitorsWeather)
-  return res
+  res.next()
 }


### PR DESCRIPTION
I _believe_ `NextResponse.next()` is being called early here, and should be the last bit called to continue the middleware chain.

Alternatively if you aren't chaining middleware, you might be able to get away with a normal `Response`.